### PR TITLE
Extension folder path from Windows registry

### DIFF
--- a/D365FONinjaDevToolsSetup/Program.cs
+++ b/D365FONinjaDevToolsSetup/Program.cs
@@ -1,33 +1,61 @@
 ﻿using System;
 using System.IO;
+using Microsoft.Win32;
+using System.Linq;
 
 namespace D365FONinjaDevToolsSetup
 {
     class Program
     {
+        private const string DllName = "D365FONinjaDevTools.dll";
+        private const string AddinFolder = "AddinExtensions";
+
         static void Main(string[] args)
         {
             try
             {
-               
-                File.Copy($@"{Environment.CurrentDirectory}\D365FONinjaDevTools.dll",
-                        @"C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\Extensions\ymhmh4ah.wnn\AddinExtensions\D365FONinjaDevTools.dll"
-                        , true);
+                string sourcePath = Path.Combine(Environment.CurrentDirectory, DllName);
+                string targetPath = Path.Combine(FindExtensionFolder(), DllName);
 
-
+                File.Copy(sourcePath, targetPath, true);
 
                 Console.WriteLine("Setup finished! Close and enjoy!");
-                Console.ReadLine();
-            
+
             }
             catch (Exception ee)
             {
-                Console.WriteLine(ee);
-                Console.WriteLine("Seems that an issue prevented me from doing my job :(");
-                Console.ReadLine();
-
+                Console.Error.WriteLine(ee);
+                Console.Error.WriteLine("Seems that an issue prevented me from doing my job :(");
             }
-            
+
+            Console.ReadLine();
+        }
+
+        private static string FindExtensionFolder()
+        {
+            using (var extensionsRegKey = Registry.CurrentUser.OpenSubKey(@"SOFTWARE\Microsoft\VisualStudio\14.0\ExtensionManager\EnabledExtensions"))
+            {
+
+                string axToolsKeyName = "";
+                string path = "";
+
+                if (extensionsRegKey != null)
+                {
+                    axToolsKeyName = extensionsRegKey.GetValueNames().Where(name => name.StartsWith("DynamicsRainierVSTools")).FirstOrDefault();
+                }
+
+                if (axToolsKeyName != null)
+                {
+                    path = (string)extensionsRegKey.GetValue(axToolsKeyName);
+                }
+
+                if (String.IsNullOrEmpty(path))
+                {
+                    throw new ApplicationException("Could not find D365FO tools in Windows registry.");
+                }
+
+                return Path.Combine(path, AddinFolder);
+            }
         }
     }
 }


### PR DESCRIPTION
The hardcoded path of Rainier extensions folder was invalid; it's different on different machines. The change extracts the value from Windows registry.